### PR TITLE
Update swag_client version to 0.2.9

### DIFF
--- a/aardvark/manage.py
+++ b/aardvark/manage.py
@@ -9,7 +9,7 @@ from bunch import Bunch
 from distutils.spawn import find_executable
 from flask import current_app
 from flask_script import Manager, Command, Option
-from swag_client import InvalidSWAGDataException
+from swag_client.exceptions import InvalidSWAGDataException
 from swag_client.swag import get_all_accounts
 
 from aardvark import create_app, db

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     'psycopg2==2.7.1',
     'pytz==2017.2',
     'subprocess32==3.2.7',
-    'swag-client==0.1.0.dev3',
+    'swag-client==0.2.9',
     'tqdm==4.11.2'
 ]
 


### PR DESCRIPTION
- Updates setup.py install_requires version of swag_client to 'swag-client==0.2.9'
- Updates manage.py to import InvalidSWAGDataException from exceptions submodule of swag_client.

