### PR TITLE
Solving swag-client 0.2.9 dependency bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ with open(os.path.join(ROOT, "aardvark", "__about__.py")) as f:
 
 
 install_requires = [
+    'requests>=2.9.1',
     'better_exceptions==0.1.7',
     'Bunch==1.0.1',
     'Flask-SQLAlchemy==2.2',


### PR DESCRIPTION
Hi,
Swag-client 0.1.0.dev3 has requirements of the module: requests, but this is gone in later versions (specifically since commit 595e49).
Requests is imported in aardvark/updater/init.py, so we should probably make that an install requirement.