### PR TITLE
add Dockerfiles and Makefile, test cases and README for docker contai…

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,5 @@
+
+aardvark
+phantomjs*
+artifacts/*
+

--- a/docker/Dockerfile.aardvark-base
+++ b/docker/Dockerfile.aardvark-base
@@ -1,0 +1,38 @@
+
+FROM python:2
+
+LABEL author="scottbrown0001@gmail.com"
+
+COPY phantomjs/bin/phantomjs /usr/local/bin
+
+COPY aardvark /tmp/aardvark
+WORKDIR /tmp/aardvark
+
+# # Update the repository and install tools and aardvark.
+# RUN apt-get update && \
+# 	apt-get install -y vim && \
+#     pip install .
+RUN pip install .
+
+# Create aardvark configuration.
+ARG AARDVARK_CONFIG_DIR="/etc/aardvark"
+ARG AARDVARK_ROLE=""
+ARG SWAG_BUCKET=""
+ARG AARDVARK_DB_URI=""
+ARG AARDVARK_DATA_DIR
+
+RUN mkdir -p $AARDVARK_CONFIG_DIR
+WORKDIR $AARDVARK_CONFIG_DIR
+
+RUN if [ -z "$AARDVARK_DB_URI" -a -n "$AARDVARK_DATA_DIR" ] ; then \
+		AARDVARK_DB_URI="sqlite:///$AARDVARK_DATA_DIR/aardvark.db"; \
+		fi; \
+	AARDVARK_CONFIG_OPTIONS=$( \
+		printf "%s%s%s" \
+			"$(if [ -n "$AARDVARK_ROLE" ] ; then echo "-a $AARDVARK_ROLE "; fi)" \
+			"$(if [ -n "$SWAG_BUCKET" ] ; then echo "-b $SWAG_BUCKET "; fi)" \
+			"$(if [ -n "$AARDVARK_DB_URI" ] ; then echo "-d $AARDVARK_DB_URI "; fi)" \
+		); \
+	aardvark config --no-prompt $AARDVARK_CONFIG_OPTIONS
+
+RUN rm -r /tmp/aardvark

--- a/docker/Dockerfile.aardvark-base
+++ b/docker/Dockerfile.aardvark-base
@@ -8,11 +8,9 @@ COPY phantomjs/bin/phantomjs /usr/local/bin
 COPY aardvark /tmp/aardvark
 WORKDIR /tmp/aardvark
 
-# # Update the repository and install tools and aardvark.
-# RUN apt-get update && \
-# 	apt-get install -y vim && \
-#     pip install .
-RUN pip install .
+# Update the repository and install aardvark.
+RUN apt-get update && \
+    pip install .
 
 # Create aardvark configuration.
 ARG AARDVARK_CONFIG_DIR="/etc/aardvark"

--- a/docker/Dockerfile.apiserver
+++ b/docker/Dockerfile.apiserver
@@ -1,0 +1,14 @@
+
+FROM aardvark-base
+
+LABEL author="scottbrown0001@gmail.com"
+
+ARG AARDVARK_DATA_DIR="/usr/share/aardvark-data"
+ENV AARDVARK_API_PORT="5000"
+
+RUN mkdir -p $AARDVARK_DATA_DIR
+
+# This is superflous unless we're using a local data volume.
+WORKDIR $AARDVARK_DATA_DIR
+
+CMD aardvark start_api -b 0.0.0.0:$AARDVARK_API_PORT

--- a/docker/Dockerfile.apiserver
+++ b/docker/Dockerfile.apiserver
@@ -1,5 +1,6 @@
 
-FROM aardvark-base
+ARG AARDVARK_IMAGES_TAG=latest
+FROM aardvark-base:${AARDVARK_IMAGES_TAG}
 
 LABEL author="scottbrown0001@gmail.com"
 

--- a/docker/Dockerfile.collector
+++ b/docker/Dockerfile.collector
@@ -1,0 +1,13 @@
+
+FROM aardvark-base
+
+LABEL author="scottbrown0001@gmail.com"
+
+ARG AARDVARK_DATA_DIR="/usr/share/aardvark-data"
+
+ENV AARDVARK_ACCOUNTS=''
+
+RUN mkdir -p $AARDVARK_DATA_DIR
+WORKDIR $AARDVARK_DATA_DIR
+
+CMD aardvark update -a $AARDVARK_ACCOUNTS

--- a/docker/Dockerfile.collector
+++ b/docker/Dockerfile.collector
@@ -1,5 +1,6 @@
 
-FROM aardvark-base
+ARG AARDVARK_IMAGES_TAG=latest
+FROM aardvark-base:${AARDVARK_IMAGES_TAG}
 
 LABEL author="scottbrown0001@gmail.com"
 

--- a/docker/Dockerfile.initialize-local-data-volume
+++ b/docker/Dockerfile.initialize-local-data-volume
@@ -1,0 +1,15 @@
+
+FROM aardvark-base
+
+LABEL author="scottbrown0001@gmail.com"
+
+ARG AARDVARK_DATA_DIR
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+RUN mkdir -p $AARDVARK_DATA_DIR
+WORKDIR $AARDVARK_DATA_DIR
+
+# We need to run this once with a volume attached when the container
+# is launched.
+CMD aardvark create_db

--- a/docker/Dockerfile.initialize-local-data-volume
+++ b/docker/Dockerfile.initialize-local-data-volume
@@ -1,5 +1,6 @@
 
-FROM aardvark-base
+ARG AARDVARK_IMAGES_TAG=latest
+FROM aardvark-base:${AARDVARK_IMAGES_TAG}
 
 LABEL author="scottbrown0001@gmail.com"
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,402 @@
+
+
+
+help:		## Display this message.
+	@printf '$(subst $(newline),\n,${HELPPROLOGUE})'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		egrep "\b(aardvark-all|aardvark-sqlite)\b" | \
+		sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m    %-24s\033[0m %s\n", $$1, $$2}'
+	@printf '$(subst $(newline),\n,${HELPINTERLUDE1})'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		grep "clean" | \
+		sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m    %-24s\033[0m %s\n", $$1, $$2}'
+	@printf '$(subst $(newline),\n,${HELPINTERLUDE2})'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		sort | \
+		egrep -v "\b(aardvark-all|aardvark-sqlite|clean.*|help)\b" | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m    %-24s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		grep help | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m    %-24s\033[0m %s\n", $$1, $$2}'
+	@printf '$(subst $(newline),\n,${HELPEPILOGUE})'
+
+define HELPPROLOGUE
+
+To build an aardvark deployment from scratch, make one of these targets:
+
+
+endef
+
+define HELPINTERLUDE1
+
+    See below for examples and for environment variable settings required to
+    properly configure your aardvark deployment and use.
+
+
+Remove intermediate and final files and/or docker images with the following
+cleanup targets:
+
+
+endef
+
+define HELPINTERLUDE2
+
+
+Additional available targets include:
+
+
+endef
+
+define HELPEPILOGUE
+
+
+Note:
+
+    * New docker images will overwrite existing images created by this Makefile.
+
+    * Nothing you can do with this Makefile will stop or remove any existing
+      container.
+
+    * Nothing you can do with this Makefile will remove or overwrite an
+      existing aardvark-data volume.
+
+
+
+Environment Variables
+=====================
+
+A number of build-time and run-time configuration options are controlled with
+environment variables.
+
+
+Configuration build-time environment variables are passed to aardvark-config
+when the base images for the aardvark collector and aardvark apiserver
+containers are built.
+
+                        aardvark
+Configuration           config
+build-time Variable     Parameter       Notes
+-------------------     ---------       ---------------------------------------
+AARDVARK_DB_URI         db-uri          Required when not using a local mysql
+                                        database.
+
+AARDVARK_ROLE           aardvark-role   Required if the sts:AssumeRole for
+                                        aardvark is not named "Aardvark".
+
+SWAG_BUCKET             swag-bucket     Required when using swag.
+
+Note that if set the values of these environment variables are automatically
+passed to the make process without any explicit passing of parameters.
+
+
+Runtime environment variables need to be set when launching the collector or
+apiserver containers.
+
+Runtime Variable        Used by         Notes
+-------------------     ---------       ---------------------------------------
+AARDVARK_ACCOUNTS       collector       Required if not using swag. Set this to
+                                        a list of AWS account numbers from
+                                        which to collect Access Advisor records.
+
+AWS_ACCESS_KEY_ID       collector       Required if not running on an EC2
+AWS_SECRET_ACCESS_KEY   collector       instance with an appropriate Instance
+                                        Profile. Set these to the credentials of
+                                        an AWS IAM user with permission to
+                                        sts:AssumeRole to the Aardvark audit
+                                        role.
+
+AARDVARK_API_PORT       apiserver       Optional. The default is 5000, and this
+                                        environment variable is unneeded if the
+                                        apiserver container is run with
+                                        "-p 127.0.0.1:80:5000".
+                                        Specifies the container port on which
+                                        the aardvark API server listens.
+
+Note that these values must be explicitly specified on the "docker run" command
+line when launching containers.
+
+
+Customization build-time variables control other aspects of the build process.
+
+Customization
+build-time Variable     Notes
+-------------------     ------------------------------------------------------
+AARDVARK_IMAGES_TAG     A common tag to apply to the docker images and volumes
+                        created by the build process.
+
+                          * If changed, be sure to run "make clean" prior to
+                            the next build.
+
+                          * If you want to remove existing images tagged with
+                            the old value, run "make clean-docker" before
+                            changing the value.
+
+
+Examples
+========
+
+Using swag
+-----------------------------------------------------------
+	$$ export SWAG_BUCKET="<swag-bucket-name>"
+	$$ make clean-all
+	$$ make aardvark-all
+	$$ docker run --rm aardvark-collector
+	$$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
+
+
+Without swag
+-----------------------------------------------------------
+	$$ make clean-all
+	$$ make aardvark-all
+	$$ export AARDVARK_ACCOUNTS="<account_number>[ account_number [...]]"
+	$$ docker run -e AARDVARK_ACCOUNTS --rm aardvark-collector
+	$$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
+
+
+Using an RDS database
+-----------------------------------------------------------
+	$$ export AARDVARK_DB_URI="<database URI>"
+	$$ make clean-all
+	$$ make aardvark-all
+	$$ docker run --rm aardvark-collector
+	$$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
+
+
+Using a local sqlite database *
+-----------------------------------------------------------
+	$$ make clean-all
+	$$ make aardvark-sqlite
+	$$ export AARDVARK_API_PORT="5000"
+	$$ docker run -v aardvark-data:/usr/share/aardvark-data --rm aardvark-collector
+	$$ docker run -v aardvark-data:/usr/share/aardvark-data -p 127.0.0.1:80:$$AARDVARK_API_PORT aardvark-apiserver
+
+	* Shown with a parameter for completeness. The API server will be listening
+	  on the port specified by the AARDVARK_API_PORT environment variable. The
+	  default is 5000, so the environment variable is not necessary if the
+	  apiserver container is started with "-p 127.0.0.1:80:5000".
+
+	* The shared volume mount point "/usr/share/aardvark-data" is created by
+	  the build process and must be specified when launching both the
+	  collector and the apiserver containers.
+
+
+Running the collector container with AWS IAM credentials *
+-----------------------------------------------------------
+
+	$$ export AWS_ACCESS_KEY_ID=<aws_access_key_id>
+	$$ export AWS_SECRET_ACCESS_KEY=<aws_secret_access_key>
+	$$ docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY --rm aardvark-collector
+
+    * Of course, do not save the AWS IAM credentials anywhere other than a
+      properly configured secrets management system.
+
+
+endef
+
+# This lets us get the HELPTEXT string across the make/shell expansion
+# combination.
+define newline
+
+
+endef
+
+
+# - - - - - - - - - - - - - - - -
+# Update these to rev the phantomjs version.
+# - - - - - - - - - - - - - - - -
+PHANTOMJS_VERSION = phantomjs-2.1.1-linux-x86_64
+PHANTOMJS_SHA = 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f
+# PHANTOMJS_2_1_1_SHA = 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f
+
+PHANTOMJS_ARCHIVE = $(PHANTOMJS_VERSION).tar.bz2
+
+# - - - - - - - - - - - - - - - -
+# Many build steps are docker build or docker run, which create no
+# actual target and would always rebuild. These files are created by
+# the corresponding build steps to indicate that the step is complete.
+# They are among those removed by "make clean".
+# - - - - - - - - - - - - - - - -
+ARTIFACTS_DIR = artifacts
+AARDVARK_BASE_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-base-docker-build
+AARDVARK_DATA_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-data-docker-build
+AARDVARK_DATA_DOCKER_RUN_PSEUDO = $(ARTIFACTS_DIR)/aardvark-data-docker-run
+AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-apiserver-docker-build
+AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-collector-docker-build
+
+# - - - - - - - - - - - - - - - -
+# These are removed by "make clean".
+# - - - - - - - - - - - - - - - -
+ALL_CLEANUP = \
+	$(AARDVARK_BASE_DOCKER_BUILD_PSEUDO) \
+	$(AARDVARK_DATA_DOCKER_BUILD_PSEUDO) \
+	$(AARDVARK_DATA_DOCKER_RUN_PSEUDO) \
+	$(AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO) \
+	$(AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO) \
+	$(PHANTOMJS_ARCHIVE) \
+	$(PHANTOMJS_ARCHIVE).shasum \
+	aardvark \
+	phantomjs*
+
+# - - - - - - - - - - - - - - - -
+# These are removed by "make clean-docker".
+# - - - - - - - - - - - - - - - -
+ALL_DOCKER_CLEANUP = \
+	aardvark-apiserver \
+	aardvark-collector \
+	aardvark-data-init \
+	aardvark-base
+
+# - - - - - - - - - - - - - - - -
+# These are target lists in multiple places.
+# - - - - - - - - - - - - - - - -
+PREREQUISITES = aardvark phantomjs
+AARDVARK_SERVICE = aardvark-collector aardvark-apiserver
+
+# - - - - - - - - - - - - - - - -
+# This is passed to the aardvark-base docker build to create the mount
+# point for the shared volume if an sqlite local database is used; the
+# same value is passed to the aardvark-data-volume build and run to
+# initialize the shared data volume. It *also* needs to be consistent
+# with the mount location specified when the apiserver and collector
+# containers are launched, but that happens outside the scope of this
+# Makefile. The example in the help text shows the correct location to
+# use.
+# - - - - - - - - - - - - - - - -
+AARDVARK_DATA_DIR = /usr/share/aardvark-data
+
+# - - - - - - - - - - - - - - - -
+# The default when invoking aardvark config with no db_uri parameter
+# is to set the DB_URI to the sqlite path to /usr/share/aardvark-data.
+# Setting AARDVARK_DATA_DIR at the aardvark-sqlite level is therefore
+# superfluous, but the value needs to be in sync with the shared data
+# volume mount point so we make it explicit here.
+# - - - - - - - - - - - - - - - -
+aardvark-sqlite $(AARDVARK_DATA_DOCKER_RUN_PSEUDO): AARDVARK_DATA_DIR = /usr/share/aardvark-data
+
+# - - - - - - - - - - - - - - - -
+# These are provided for entry points (the <X> in "make <X>"). They
+# have no (real or stand-in) targets and should not be used as
+# dependencies as this will always trigger upstream rebuilds.
+# - - - - - - - - - - - - - - - -
+aardvark-all: $(AARDVARK_SERVICE)		## Build the aardvark collector and apiserver docker images.
+aardvark-sqlite: $(AARDVARK_DATA_DOCKER_RUN_PSEUDO) $(AARDVARK_SERVICE) ## Build the collector and apiserver images and initialize a shared volume sqlite database.
+aardvark-apiserver: $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO) $(AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO)		## Build the aardvark apiserver docker image.
+aardvark-collector: $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO) $(AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO)		## Build the aardvark collector docker image.
+aardvark-data-volume: $(AARDVARK_DATA_DOCKER_RUN_PSEUDO)		## Create and initialize the aardvark local sqlite database shared volume.
+aardvark-base: $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO)	## Create the base docker image for subsequent aardvark images.
+prerequisites: $(PREREQUISITES)		## Fetch the phantomjs package and the aardvark repository if not present.
+
+# - - - - - - - - - - - - - - - -
+.PHONY: clean clean-docker clean-all help
+
+clean:		## Remove build artifacts (intermediate, target and pseudo-target files and directories).
+	-rm -rf $(ALL_CLEANUP)
+
+clean-docker:		## Remove existing docker images (prompts for confirmation).
+	@echo "This will remove the following docker images if they exist:"; \
+	for image in $(ALL_DOCKER_CLEANUP) ; do \
+		echo "    $$image$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)"; \
+		done; \
+    read -p "Proceed? (y/n) " response; \
+    case $$response in \
+        [Yy]* ) break;; \
+        * ) echo "skipping docker cleanup"; exit;; \
+	    esac; \
+	for image in $(ALL_DOCKER_CLEANUP) ; do \
+		if [ -n "$$(docker image ls "$$image$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" | grep -v REPOSITORY)" ]; then \
+			echo "removing $$image with \"docker image rm $$image\""; \
+			docker image rm "$$image$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)"; \
+			fi; \
+		done
+
+clean-all: clean clean-docker		## Equivalent to 'make clean' and 'make clean-docker'.
+
+# - - - - - - - - - - - - - - - -
+$(AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO):
+	docker build \
+		-t "aardvark-collector$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
+		-f Dockerfile.collector \
+		.; \
+	AARDVARK_COLLECTOR_IMAGE_LS=$$(docker image ls | egrep "aardvark-collector *$$AARDVARK_IMAGES_TAG"); \
+	mkdir -p $(ARTIFACTS_DIR); \
+	rm -f $(AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO); \
+	if [ -n "$$AARDVARK_COLLECTOR_IMAGE_LS" ] ; then \
+		echo "$$AARDVARK_COLLECTOR_IMAGE_LS" > $(AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO); \
+		fi
+
+# - - - - - - - - - - - - - - - -
+$(AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO):
+	docker build \
+		-t "aardvark-apiserver$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
+		-f Dockerfile.apiserver \
+		.; \
+	AARDVARK_APISERVER_IMAGE_LS=$$(docker image ls | egrep "aardvark-apiserver *$$AARDVARK_IMAGES_TAG"); \
+	mkdir -p $(ARTIFACTS_DIR); \
+	rm -f $(AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO); \
+	if [ -n "$$AARDVARK_APISERVER_IMAGE_LS" ] ; then \
+		echo "$$AARDVARK_APISERVER_IMAGE_LS" > $(AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO); \
+		fi
+
+# - - - - - - - - - - - - - - - -
+$(AARDVARK_DATA_DOCKER_RUN_PSEUDO): $(AARDVARK_DATA_DOCKER_BUILD_PSEUDO)
+	mkdir -p $(ARTIFACTS_DIR); \
+	if [ -n "$$(docker volume ls | egrep "\baardvark-data$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "-$$AARDVARK_IMAGES_TAG"; fi)$$")" ] ; then \
+		echo "Using existing aardvark-data docker volume"; \
+		echo "Using existing aardvark-data docker volume" > $(AARDVARK_DATA_DOCKER_RUN_PSEUDO); \
+	else \
+		docker volume create aardvark-data; \
+		rm -f $(AARDVARK_DATA_DOCKER_RUN_PSEUDO); \
+		docker run -v aardvark-data$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "-$$AARDVARK_IMAGES_TAG"; fi):$(AARDVARK_DATA_DIR) --rm aardvark-data-init$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi); \
+		echo "initialized data directory $(AARDVARK_DATA_DIR)" > $(AARDVARK_DATA_DOCKER_RUN_PSEUDO); \
+		fi
+
+$(AARDVARK_DATA_DOCKER_BUILD_PSEUDO): $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO)
+	docker build \
+		-t "aardvark-data-init$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
+		-f Dockerfile.initialize-local-data-volume  \
+		--build-arg AARDVARK_DATA_DIR=$(AARDVARK_DATA_DIR) \
+		.; \
+	AARDVARK_DATA_INIT_IMAGE_LS=$$(docker image ls | egrep "aardvark-data-init *$$AARDVARK_IMAGES_TAG"); \
+	mkdir -p $(ARTIFACTS_DIR); \
+	rm -f $(AARDVARK_DATA_DOCKER_BUILD_PSEUDO); \
+	if [ -n "$$AARDVARK_DATA_INIT_IMAGE_LS" ] ; then \
+		echo "$$AARDVARK_DATA_INIT_IMAGE_LS" > $(AARDVARK_DATA_DOCKER_BUILD_PSEUDO); \
+		fi
+
+# - - - - - - - - - - - - - - - -
+$(AARDVARK_BASE_DOCKER_BUILD_PSEUDO): $(PREREQUISITES)
+
+	docker build \
+		-t "aardvark-base$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
+		-f Dockerfile.aardvark-base \
+		--build-arg AARDVARK_DATA_DIR=$(AARDVARK_DATA_DIR) \
+		--build-arg AARDVARK_DB_URI \
+		--build-arg AARDVARK_ROLE \
+		--build-arg SWAG_BUCKET \
+		.; \
+	AARDVARK_BASE_IMAGE_LS=$$(docker image ls | egrep "aardvark-base *$$AARDVARK_IMAGES_TAG"); \
+	mkdir -p $(ARTIFACTS_DIR); \
+	rm -f $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO); \
+	if [ -n "$$AARDVARK_BASE_IMAGE_LS" ] ; then \
+		echo "$$AARDVARK_BASE_IMAGE_LS" > $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO); \
+		fi
+
+# - - - - - - - - - - - - - - - -
+phantomjs: $(PHANTOMJS_VERSION)		## Fetch the phantomjs package.
+	ln -s $(PHANTOMJS_VERSION) phantomjs
+
+$(PHANTOMJS_VERSION): $(PHANTOMJS_ARCHIVE)
+	rm -f $(PHANTOMJS_ARCHIVE).shasum
+	echo "$(PHANTOMJS_SHA)  $(PHANTOMJS_ARCHIVE)" > $(PHANTOMJS_ARCHIVE).shasum
+	@shasum -c $(PHANTOMJS_ARCHIVE).shasum
+	tar -xf $(PHANTOMJS_ARCHIVE) $(PHANTOMJS_VERSION)
+
+$(PHANTOMJS_ARCHIVE):
+	curl -Ls https://bitbucket.org/ariya/phantomjs/downloads/$(PHANTOMJS_ARCHIVE) > $(PHANTOMJS_ARCHIVE)
+
+# - - - - - - - - - - - - - - - -
+aardvark:		## Clone the aardvark repository.
+	git clone https://github.com/Netflix-Skunkworks/aardvark.git

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -32,8 +32,12 @@ endef
 
 define HELPINTERLUDE1
 
+    The aardvark-sqlite build includes all the products from the aardvark-all
+    build, and additionally creates and initializes a shared data volume for
+    the sqlite database.
+
     See below for examples and for environment variable settings required to
-    properly configure your aardvark deployment and use.
+    properly configure your aardvark containers build and deployment.
 
 
 Remove intermediate and final files and/or docker images with the following
@@ -73,17 +77,17 @@ Note:
 Environment Variables
 =====================
 
-A number of build-time and run-time configuration options are controlled with
+A number of build time and run-time configuration options are controlled with
 environment variables.
 
 
-Configuration build-time environment variables are passed to aardvark-config
+Configuration build time environment variables are passed to aardvark-config
 when the base images for the aardvark collector and aardvark apiserver
 containers are built.
 
                         aardvark
 Configuration           config
-build-time Variable     Parameter       Notes
+Build Time Variable     Parameter       Notes
 -------------------     ---------       ---------------------------------------
 AARDVARK_DB_URI         db-uri          Required when not using a local mysql
                                         database.
@@ -91,7 +95,7 @@ AARDVARK_DB_URI         db-uri          Required when not using a local mysql
 AARDVARK_ROLE           aardvark-role   Required if the sts:AssumeRole for
                                         aardvark is not named "Aardvark".
 
-SWAG_BUCKET             swag-bucket     Required when using swag.
+SWAG_BUCKET             swag-bucket     Required when using SWAG.
 
 Note that if set the values of these environment variables are automatically
 picked up by the make process without any explicit passing of parameters.
@@ -102,9 +106,11 @@ apiserver containers.
 
 Runtime Variable        Used by         Notes
 -------------------     ---------       ---------------------------------------
-AARDVARK_ACCOUNTS       collector       Required if not using swag. Set this to
-                                        a list of AWS account numbers from
-                                        which to collect Access Advisor records.
+AARDVARK_ACCOUNTS       collector       Optional if using SWAG, otherwise
+                                        required. Set this to a list of SWAG
+                                        account name tags or a list of AWS
+                                        account numbers from which to collect
+                                        Access Advisor records.
 
 AWS_ACCESS_KEY_ID       collector       Required if not running on an EC2
 AWS_SECRET_ACCESS_KEY   collector       instance with an appropriate Instance
@@ -128,10 +134,10 @@ Note that these values must be explicitly specified on the "docker run" command
 line when launching containers.
 
 
-Customization build-time variables control other aspects of the build process.
+Customization build time variables control other aspects of the build process.
 
 Customization
-build-time Variable     Notes
+Build Time Variable     Notes
 -------------------     ------------------------------------------------------
 AARDVARK_IMAGES_TAG     A common tag to apply to the docker images and volumes
                         created by the build process.
@@ -147,56 +153,70 @@ AARDVARK_IMAGES_TAG     A common tag to apply to the docker images and volumes
 Examples
 ========
 
-Using swag
+
+A typical production deployment
 -----------------------------------------------------------
+
+    Here we see the settings and build steps to create and run a typical
+    production deployment, using SWAG and an RDS database, on an EC2 instance
+    with an instance profile granting the required sts::AssumeRole permissions.
+
+    $$ export AARDVARK_ROLE="<MyAardvarkRoleName>"
+    $$ export AARDVARK_DB_URI="<database URI>"
     $$ export SWAG_BUCKET="<swag-bucket-name>"
     $$ make clean-all
     $$ make aardvark-all
-    $$ docker run --rm aardvark-collector
-    $$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
+    $$ docker run -v aardvark-data:/usr/share/aardvark-data --rm aardvark-collector
+    $$ docker run -v aardvark-data:/usr/share/aardvark-data \\
+      -p 127.0.0.1:80:5000 aardvark-apiserver
+
+    * The SWAG_BUCKET build time environment variable is set so that aardvark
+      will be configured to use SWAG.
+
+    * The AARDVARK_DB_URI build time environment variable is set to point to
+      the appropriate external database.
+
+    * With SWAG the AARDVARK_ACCOUNTS runtime environment variable is optional.
+      Set it to a list of SWAG account name tags to collect from or leave it
+      undefined to collect from all accounts known to SWAG.
 
 
-Without swag
+A typical standalone or test deployment
 -----------------------------------------------------------
-    $$ make clean-all
-    $$ make aardvark-all
-    $$ export AARDVARK_ACCOUNTS="<account_number>[ account_number [...]]"
-    $$ docker run -e AARDVARK_ACCOUNTS --rm aardvark-collector
-    $$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
 
+    Here we see the settings and build steps to create and run a typical
+    deployment in a standalone environment such as might be used for local
+    testing.
 
-Using an RDS database
------------------------------------------------------------
-    $$ export AARDVARK_DB_URI="<database URI>"
-    $$ make clean-all
-    $$ make aardvark-all
-    $$ docker run --rm aardvark-collector
-    $$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
-
-
-Using a local sqlite database *
------------------------------------------------------------
+    $$ export AARDVARK_ROLE="<MyAardvarkRoleName>"
     $$ make clean-all
     $$ make aardvark-sqlite
-    $$ export AARDVARK_API_PORT="5000"
-    $$ docker run -v aardvark-data:/usr/share/aardvark-data --rm aardvark-collector
-    $$ docker run -v aardvark-data:/usr/share/aardvark-data -p 127.0.0.1:80:5000 aardvark-apiserver
-
-    * The shared volume mount point "/usr/share/aardvark-data" is created when
-      the docker images are built and must be specified when launching both the
-      collector and the apiserver containers.
-
-
-Running the collector container with AWS IAM credentials *
------------------------------------------------------------
-
     $$ export AWS_ACCESS_KEY_ID=<aws_access_key_id>
     $$ export AWS_SECRET_ACCESS_KEY=<aws_secret_access_key>
-    $$ docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY --rm aardvark-collector
+    $$ export AARDVARK_ACCOUNTS="<account_number>[ account_number [...]]"
+    $$ docker run -v aardvark-data:/usr/share/aardvark-data \\
+      -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \\
+      -e AARDVARK_ACCOUNTS --rm aardvark-collector
+    $$ docker run -v aardvark-data:/usr/share/aardvark-data \\
+      -p 127.0.0.1:80:5000 aardvark-apiserver
+
+    * The AARDVARK_ACCOUNTS runtime environment variable is used to pass one or
+      more AWS account numbers directly to the aardvark-collector container.
+
+    * In contrast to running on an EC2 instance configured with an Instance
+      Profile that provides the collector with necessary sts::AssumeRole
+      permissions, the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY runtime
+      environment variables are set to specify an AWS IAM user with the
+      necessary permissions.
+
+    * At runtime the aardvark-data shared volume providing a local sqlite
+      database is mounted on both the collector and the apiserver. The mount
+      point "/usr/share/aardvark-data" is created when the docker images are
+      built.
 
     * The underlying boto3 library will automatically use the credentials it
-      finds in the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
-      variables.
+      finds in the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY runtime
+      environment variables.
 
       Be aware that setting these in the container runtime environment makes
       them visible to anyone who can attach a shell to the running container,
@@ -293,18 +313,18 @@ aardvark-sqlite $(AARDVARK_DATA_DOCKER_RUN_PSEUDO): AARDVARK_DATA_DIR = /usr/sha
 # have no (real or stand-in) targets and should not be used as
 # dependencies as this will always trigger upstream rebuilds.
 # - - - - - - - - - - - - - - - -
-aardvark-all: $(AARDVARK_SERVICE)		## Build the aardvark collector and apiserver docker images.
-aardvark-sqlite: $(AARDVARK_DATA_DOCKER_RUN_PSEUDO) $(AARDVARK_SERVICE) ## Build the collector and apiserver images and initialize a shared volume sqlite database.
+aardvark-all: $(AARDVARK_SERVICE)		## Build the collector and apiserver docker images.
+aardvark-sqlite: $(AARDVARK_DATA_DOCKER_RUN_PSEUDO) $(AARDVARK_SERVICE) ## Build aardvark-all and a shared volume sqlite database.
 aardvark-apiserver: $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO) $(AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO)		## Build the aardvark apiserver docker image.
 aardvark-collector: $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO) $(AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO)		## Build the aardvark collector docker image.
-aardvark-data-volume: $(AARDVARK_DATA_DOCKER_RUN_PSEUDO)		## Create and initialize the aardvark local sqlite database shared volume.
+aardvark-data-volume: $(AARDVARK_DATA_DOCKER_RUN_PSEUDO)		## Create and initialize the sqlite database shared volume.
 aardvark-base: $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO)	## Create the base docker image for subsequent aardvark images.
-prerequisites: $(PREREQUISITES)		## Fetch the phantomjs package and the aardvark repository if not present.
+prerequisites: $(PREREQUISITES)		## Fetch the phantomjs package and aardvark repository if not present.
 
 # - - - - - - - - - - - - - - - -
 .PHONY: clean clean-docker clean-all help
 
-clean:		## Remove build artifacts (intermediate, target and pseudo-target files and directories).
+clean:		## Remove intermediate, target and pseudo-target files and directories.
 	-rm -rf $(ALL_CLEANUP)
 
 clean-docker:		## Remove existing docker images (prompts for confirmation).

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -383,7 +383,6 @@ $(AARDVARK_DATA_DOCKER_BUILD_PSEUDO): $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO)
 
 # - - - - - - - - - - - - - - - -
 $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO): $(PREREQUISITES)
-
 	docker build \
 		-t "aardvark-base$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
 		-f Dockerfile.aardvark-base \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -331,7 +331,7 @@ $(AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO):
 	docker build \
 		-t "aardvark-collector$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
 		-f Dockerfile.collector \
-		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; fi) \
+		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; else echo "latest"; fi) \
 		.; \
 	AARDVARK_COLLECTOR_IMAGE_LS=$$(docker image ls | egrep "aardvark-collector *$$AARDVARK_IMAGES_TAG"); \
 	mkdir -p $(ARTIFACTS_DIR); \
@@ -345,7 +345,7 @@ $(AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO):
 	docker build \
 		-t "aardvark-apiserver$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
 		-f Dockerfile.apiserver \
-		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; fi) \
+		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; else echo "latest"; fi) \
 		.; \
 	AARDVARK_APISERVER_IMAGE_LS=$$(docker image ls | egrep "aardvark-apiserver *$$AARDVARK_IMAGES_TAG"); \
 	mkdir -p $(ARTIFACTS_DIR); \
@@ -361,7 +361,7 @@ $(AARDVARK_DATA_DOCKER_RUN_PSEUDO): $(AARDVARK_DATA_DOCKER_BUILD_PSEUDO)
 		echo "Using existing aardvark-data docker volume"; \
 		echo "Using existing aardvark-data docker volume" > $(AARDVARK_DATA_DOCKER_RUN_PSEUDO); \
 	else \
-		docker volume create aardvark-data; \
+		docker volume create aardvark-data$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "-$$AARDVARK_IMAGES_TAG"; fi); \
 		rm -f $(AARDVARK_DATA_DOCKER_RUN_PSEUDO); \
 		docker run -v aardvark-data$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "-$$AARDVARK_IMAGES_TAG"; fi):$(AARDVARK_DATA_DIR) --rm aardvark-data-init$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi); \
 		echo "initialized data directory $(AARDVARK_DATA_DIR)" > $(AARDVARK_DATA_DOCKER_RUN_PSEUDO); \
@@ -371,7 +371,7 @@ $(AARDVARK_DATA_DOCKER_BUILD_PSEUDO): $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO)
 	docker build \
 		-t "aardvark-data-init$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
 		-f Dockerfile.initialize-local-data-volume  \
-		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; fi) \
+		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; else echo "latest"; fi) \
 		--build-arg AARDVARK_DATA_DIR=$(AARDVARK_DATA_DIR) \
 		.; \
 	AARDVARK_DATA_INIT_IMAGE_LS=$$(docker image ls | egrep "aardvark-data-init *$$AARDVARK_IMAGES_TAG"); \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -232,11 +232,11 @@ PHANTOMJS_ARCHIVE = $(PHANTOMJS_VERSION).tar.bz2
 # They are among those removed by "make clean".
 # - - - - - - - - - - - - - - - -
 ARTIFACTS_DIR = artifacts
-AARDVARK_BASE_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-base-docker-build
-AARDVARK_DATA_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-data-docker-build
-AARDVARK_DATA_DOCKER_RUN_PSEUDO = $(ARTIFACTS_DIR)/aardvark-data-docker-run
-AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-apiserver-docker-build
-AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-collector-docker-build
+AARDVARK_BASE_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-base-docker-build-$(AARDVARK_IMAGES_TAG)
+AARDVARK_DATA_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-data-docker-build-$(AARDVARK_IMAGES_TAG)
+AARDVARK_DATA_DOCKER_RUN_PSEUDO = $(ARTIFACTS_DIR)/aardvark-data-docker-run-$(AARDVARK_IMAGES_TAG)
+AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-apiserver-docker-build-$(AARDVARK_IMAGES_TAG)
+AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO = $(ARTIFACTS_DIR)/aardvark-collector-docker-build-$(AARDVARK_IMAGES_TAG)
 
 # - - - - - - - - - - - - - - - -
 # These are removed by "make clean".
@@ -331,6 +331,7 @@ $(AARDVARK_COLLECTOR_DOCKER_BUILD_PSEUDO):
 	docker build \
 		-t "aardvark-collector$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
 		-f Dockerfile.collector \
+		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; fi) \
 		.; \
 	AARDVARK_COLLECTOR_IMAGE_LS=$$(docker image ls | egrep "aardvark-collector *$$AARDVARK_IMAGES_TAG"); \
 	mkdir -p $(ARTIFACTS_DIR); \
@@ -344,6 +345,7 @@ $(AARDVARK_APISERVER_DOCKER_BUILD_PSEUDO):
 	docker build \
 		-t "aardvark-apiserver$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
 		-f Dockerfile.apiserver \
+		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; fi) \
 		.; \
 	AARDVARK_APISERVER_IMAGE_LS=$$(docker image ls | egrep "aardvark-apiserver *$$AARDVARK_IMAGES_TAG"); \
 	mkdir -p $(ARTIFACTS_DIR); \
@@ -369,6 +371,7 @@ $(AARDVARK_DATA_DOCKER_BUILD_PSEUDO): $(AARDVARK_BASE_DOCKER_BUILD_PSEUDO)
 	docker build \
 		-t "aardvark-data-init$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo ":$$AARDVARK_IMAGES_TAG"; fi)" \
 		-f Dockerfile.initialize-local-data-volume  \
+		--build-arg AARDVARK_IMAGES_TAG=$$(if [ -n "$$AARDVARK_IMAGES_TAG" ] ; then echo "$$AARDVARK_IMAGES_TAG"; fi) \
 		--build-arg AARDVARK_DATA_DIR=$(AARDVARK_DATA_DIR) \
 		.; \
 	AARDVARK_DATA_INIT_IMAGE_LS=$$(docker image ls | egrep "aardvark-data-init *$$AARDVARK_IMAGES_TAG"); \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -56,12 +56,17 @@ define HELPEPILOGUE
 Note:
 
     * New docker images will overwrite existing images created by this Makefile.
+      Set the AARDVARK_IMAGES_TAG environment variable to specify a tag to
+      distinguish new images created with this Makefile from existing images.
 
     * Nothing you can do with this Makefile will stop or remove any existing
       container.
 
     * Nothing you can do with this Makefile will remove or overwrite an
-      existing aardvark-data volume.
+      existing aardvark-data volume. If the AARDVARK_IMAGES_TAG environment
+      variable is set when you make the aardvark-sqlite or the
+      aardvark-data-volume target, a new aardvark-data-$$AARDVARK_IMAGES_TAG
+      volume will be created if it does not already exist.
 
 
 
@@ -89,7 +94,7 @@ AARDVARK_ROLE           aardvark-role   Required if the sts:AssumeRole for
 SWAG_BUCKET             swag-bucket     Required when using swag.
 
 Note that if set the values of these environment variables are automatically
-passed to the make process without any explicit passing of parameters.
+picked up by the make process without any explicit passing of parameters.
 
 
 Runtime environment variables need to be set when launching the collector or
@@ -108,12 +113,16 @@ AWS_SECRET_ACCESS_KEY   collector       instance with an appropriate Instance
                                         sts:AssumeRole to the Aardvark audit
                                         role.
 
-AARDVARK_API_PORT       apiserver       Optional. The default is 5000, and this
+AARDVARK_API_PORT       apiserver       Optional. Specifies the container port 
+                                        on which the aardvark API server
+                                        listens. The default is 5000, and this
                                         environment variable is unneeded if the
                                         apiserver container is run with
-                                        "-p 127.0.0.1:80:5000".
-                                        Specifies the container port on which
-                                        the aardvark API server listens.
+                                        "-p 127.0.0.1:[HOST_PORT]:5000".
+                                        If for some reason you do set this
+                                        variable, run the aardvark apiserver
+                                        with the $$AARDVARK_API_PORT published
+                                        to the host.
 
 Note that these values must be explicitly specified on the "docker run" command
 line when launching containers.
@@ -140,58 +149,61 @@ Examples
 
 Using swag
 -----------------------------------------------------------
-	$$ export SWAG_BUCKET="<swag-bucket-name>"
-	$$ make clean-all
-	$$ make aardvark-all
-	$$ docker run --rm aardvark-collector
-	$$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
+    $$ export SWAG_BUCKET="<swag-bucket-name>"
+    $$ make clean-all
+    $$ make aardvark-all
+    $$ docker run --rm aardvark-collector
+    $$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
 
 
 Without swag
 -----------------------------------------------------------
-	$$ make clean-all
-	$$ make aardvark-all
-	$$ export AARDVARK_ACCOUNTS="<account_number>[ account_number [...]]"
-	$$ docker run -e AARDVARK_ACCOUNTS --rm aardvark-collector
-	$$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
+    $$ make clean-all
+    $$ make aardvark-all
+    $$ export AARDVARK_ACCOUNTS="<account_number>[ account_number [...]]"
+    $$ docker run -e AARDVARK_ACCOUNTS --rm aardvark-collector
+    $$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
 
 
 Using an RDS database
 -----------------------------------------------------------
-	$$ export AARDVARK_DB_URI="<database URI>"
-	$$ make clean-all
-	$$ make aardvark-all
-	$$ docker run --rm aardvark-collector
-	$$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
+    $$ export AARDVARK_DB_URI="<database URI>"
+    $$ make clean-all
+    $$ make aardvark-all
+    $$ docker run --rm aardvark-collector
+    $$ docker run -p 127.0.0.1:80:5000 aardvark-apiserver
 
 
 Using a local sqlite database *
 -----------------------------------------------------------
-	$$ make clean-all
-	$$ make aardvark-sqlite
-	$$ export AARDVARK_API_PORT="5000"
-	$$ docker run -v aardvark-data:/usr/share/aardvark-data --rm aardvark-collector
-	$$ docker run -v aardvark-data:/usr/share/aardvark-data -p 127.0.0.1:80:$$AARDVARK_API_PORT aardvark-apiserver
+    $$ make clean-all
+    $$ make aardvark-sqlite
+    $$ export AARDVARK_API_PORT="5000"
+    $$ docker run -v aardvark-data:/usr/share/aardvark-data --rm aardvark-collector
+    $$ docker run -v aardvark-data:/usr/share/aardvark-data -p 127.0.0.1:80:5000 aardvark-apiserver
 
-	* Shown with a parameter for completeness. The API server will be listening
-	  on the port specified by the AARDVARK_API_PORT environment variable. The
-	  default is 5000, so the environment variable is not necessary if the
-	  apiserver container is started with "-p 127.0.0.1:80:5000".
-
-	* The shared volume mount point "/usr/share/aardvark-data" is created by
-	  the build process and must be specified when launching both the
-	  collector and the apiserver containers.
+    * The shared volume mount point "/usr/share/aardvark-data" is created when
+      the docker images are built and must be specified when launching both the
+      collector and the apiserver containers.
 
 
 Running the collector container with AWS IAM credentials *
 -----------------------------------------------------------
 
-	$$ export AWS_ACCESS_KEY_ID=<aws_access_key_id>
-	$$ export AWS_SECRET_ACCESS_KEY=<aws_secret_access_key>
-	$$ docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY --rm aardvark-collector
+    $$ export AWS_ACCESS_KEY_ID=<aws_access_key_id>
+    $$ export AWS_SECRET_ACCESS_KEY=<aws_secret_access_key>
+    $$ docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY --rm aardvark-collector
 
-    * Of course, do not save the AWS IAM credentials anywhere other than a
-      properly configured secrets management system.
+    * The underlying boto3 library will automatically use the credentials it
+      finds in the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
+      variables.
+
+      Be aware that setting these in the container runtime environment makes
+      them visible to anyone who can attach a shell to the running container,
+      but does not make them visible in the underlying image or its history.
+
+      Of course, do not save the AWS IAM credentials anywhere other than your
+      .aws/credentials file.
 
 
 endef

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -72,6 +72,10 @@ Note:
       aardvark-data-volume target, a new aardvark-data-$$AARDVARK_IMAGES_TAG
       volume will be created if it does not already exist.
 
+    * When the "true" make targets are docker images, "pseudo" target files are
+      created in the artifacts directory. These pseudo-targets are what the
+      "make clean" command removes; the actual docker images will be removed
+      by "make clean-docker".
 
 
 Environment Variables

--- a/docker/README
+++ b/docker/README
@@ -1,0 +1,2 @@
+Run "make help" for usage documentation.
+

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -1,0 +1,853 @@
+'''Test cases for docker container creation.
+'''
+
+import logging
+import os
+import random
+import re
+import shutil
+import tempfile
+
+import unittest
+
+import pexpect
+
+
+# Configure logging. Troubleshooting the pexpect interactions in
+# particular needs a lot of tracing.
+FILENAME = os.path.split(__file__)[-1]
+shandler = logging.StreamHandler()
+sformatter = logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+shandler.setFormatter(sformatter)
+logger = logging.getLogger()
+logger.setLevel(logging.WARNING)
+# logger.setLevel(logging.INFO)
+# logger.setLevel(logging.DEBUG)
+logger.addHandler(shandler)
+
+# We'll copy the docker directory contents to the temporary working
+# directory each time.
+DOCKER_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    "docker"
+    )
+
+# An index of possible docker images and their pseudo-artifacts.
+DOCKER_IMAGES = {
+    'aardvark-base': 'aardvark-base-docker-build',
+    'aardvark-data-volume': 'aardvark-data-docker-build',
+    'aardvark-data-volume': 'aardvark-data-docker-run',
+    'aardvark-apiserver': 'aardvark-apiserver-docker-build',
+    'aardvark-collector': 'aardvark-collector-docker-build',
+    }
+
+# The subdirectory of the working directory where pseudo-artifacts
+# are created.
+ARTIFACT_DIRECTORY = 'artifacts'
+
+CONTAINER_CONFIG_PATH = '/etc/aardvark/config.py'
+CONTAINER_PHANTOMJS_PERMS = 'rwxr-xr-x'
+
+# Making targets can take some time, and depends on network connection
+# speed. Set the NETWORK_SPEED_FACTOR environment variable to increase
+# if necessary.
+PEXPECT_TIMEOUTS = {
+    'default': 30,
+    'container_command': 2,
+    'aardvark': 30,
+    'aardvark-all': 240,
+    'aardvark-base': 180,
+    'aardvark-sqlite': 300,
+    'phantomjs': 30,
+    }
+NETWORK_SPEED_FACTOR = 1.0
+
+EXPECTED_SQLITE_DB_URI = 'sqlite:////usr/share/aardvark-data/aardvark.db'
+EXPECTED_PHANTOMJS_PATH = '/usr/local/bin/phantomjs'
+EXPECTED_SQL_TRACK_MODS = False
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+def sqlite_db_uri(path):
+    '''Return the default db_uri value at runtime.'''
+    return 'sqlite:///{}/aardvark.db'.format(path)
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+def copy_recipes(src, dest):
+    '''Copy Make- and Dockerfiles from src to dest'''
+    [
+        shutil.copyfile(os.path.join(src, f), os.path.join(dest, f))
+        for f in os.listdir(src)
+        if (f.startswith("Dockerfile") or f.startswith("Makefile"))
+        ]
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+def interact(
+        spawn,
+        command,
+        response_filter=None,
+        timeout=PEXPECT_TIMEOUTS['container_command']
+        ):  # pylint: disable=bad-continuation
+    '''Send command to spawn and return filtered response.'''
+
+    def default_response_filter(response):
+        '''Define a default method for the response filter.'''
+        return response
+
+    if not response_filter:
+        response_filter = default_response_filter
+
+    shell_prompt = r'root@\w+:[\S]+# '
+    expect_prompt = [shell_prompt, pexpect.EOF, pexpect.TIMEOUT]
+
+    eof_position = expect_prompt.index(pexpect.EOF)
+    timeout_position = expect_prompt.index(pexpect.TIMEOUT)
+
+    eof_msg_template = 'unexpected EOF in pexpect connection to {}'
+    responses = []
+    result = None
+
+    logger.info('COMMAND:\t%s', command)
+    spawn.sendline(command)
+
+    # Read until we time out, indicating no more lines are pending;
+    # watch for the response that has our command echoed on one line
+    # and our response on the next.
+    while(True):
+
+        prompt_index = spawn.expect(expect_prompt, timeout=timeout)
+
+        import json
+        if prompt_index < timeout_position:
+            responses.append(
+                spawn.before.replace('\r\n', '\n')
+                )
+            # print '--------'
+            logger.debug('    BEFORE: %s', json.dumps(responses[-1]))
+            logger.debug(
+                '    AFTER: %s',
+                json.dumps(spawn.after.replace('\r\n', '\n'))
+                )
+            if command and responses[-1].startswith(command + '\n'):
+                result = response_filter(
+                    responses[-1].replace(command + '\n', '', 1).strip()
+                    )
+                logger.info("    result found: %s", result)
+            # print '--------\n'
+
+        elif prompt_index == timeout_position:
+            logger.debug('    TIMEOUT')
+            break
+
+        elif prompt_index == eof_position:
+            raise RuntimeError(eof_msg_template.format(command))
+
+    logger.debug('Responses:\n%s', '\n'.join(responses))
+    logger.debug('')
+
+    return result
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class TestDockerBase(unittest.TestCase):
+    '''Base class for docker container construction test cases.'''
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    @classmethod
+    def setUpClass(cls):
+        '''Test case class common fixture setup.'''
+
+        cls.original_docker_images = cls.get_docker_image_list()
+        cls.original_docker_containers = cls.get_docker_container_list()
+        cls.original_docker_volumes = cls.get_docker_volume_list()
+
+        cls.tmpdir = tempfile.mkdtemp()
+
+        cls.original_working_dir = os.getcwd()
+        os.chdir(cls.tmpdir)
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    @classmethod
+    def tearDownClass(cls):
+        '''Test case class common fixture teardown.'''
+
+        os.chdir(cls.original_working_dir)
+        cls.clean_tmpdir()
+        os.rmdir(cls.tmpdir)
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    @classmethod
+    def clean_tmpdir(cls):
+        '''Remove all content from cls.tmpdir.'''
+
+        for root, dirs, files in os.walk(cls.tmpdir, topdown=False):
+
+            for name in files:
+
+                path = os.path.join(root, name)
+                os.remove(path)
+
+            for name in dirs:
+
+                path = os.path.join(root, name)
+                if os.path.islink(path):
+                    os.remove(path)
+                else:
+                    os.rmdir(path)
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def setUp(self):
+        '''Test case common fixture setup.'''
+
+        self.clean_tmpdir()
+
+        # This copies the Makefile and the Dockerfiles.
+        copy_recipes(DOCKER_PATH, self.tmpdir)
+
+        # We track to make sure we don't disturb any files that were
+        # present in the working directory.
+        self.initial_contents = os.listdir(self.tmpdir)
+
+        # If true, we will stop containers and delete images created
+        # during each test case.
+        self.delete_artifacts = True
+
+        # A (almost certainly) unique string for unique test case
+        # artifact names.
+        self.testcase_tag = (
+            'test{:08X}'.format(random.randrange(16 ** 8)).lower()
+            )
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def tearDown(self):
+        '''Test case common fixture teardown.'''
+
+        logger.info("======= tearDown: %s", self.delete_artifacts)
+
+        if self.delete_artifacts:
+
+            # Every case should clean up its docker images and containers.
+            new_containers = [
+                c for c in self.get_docker_container_list()
+                if c['id'] not in [
+                    x['id'] for x in self.original_docker_containers
+                    ]
+                ]
+
+            new_images = [
+                i for i in self.get_docker_image_list()
+                if i['id'] not in [
+                    x['id'] for x in self.original_docker_images
+                    ]
+                ]
+
+            new_volumes = [
+                i for i in self.get_docker_volume_list()
+                if i['name'] not in [
+                    x['name'] for x in self.original_docker_volumes
+                    ]
+                ]
+
+            def log_listing(caption, records, *fields):
+                '''Helper method for log message construction.'''
+
+                return '{}:\n    '.format(caption) + '\n    '.join([
+                    '\t'.join(
+                        [record[field] for field in fields]
+                        ) for record in records
+                    ])
+            container_fields = ['id', 'name']
+            image_fields = ['id', 'name', 'tag']
+            volume_fields = ['name']
+
+            logger.info("------------containers:")
+            logger.info(log_listing(
+                'Original', self.original_docker_containers, *container_fields
+                ))
+            logger.info(log_listing(
+                'Current', self.get_docker_container_list(), *container_fields
+                ))
+            logger.info(log_listing(
+                'New', new_containers, *container_fields
+                ))
+
+            logger.info("------------images:")
+            logger.info(log_listing(
+                'Original', self.original_docker_images, *image_fields
+                ))
+            logger.info(log_listing(
+                'Current', self.get_docker_image_list(), *image_fields
+                ))
+            logger.info(log_listing(
+                'New', new_images, *image_fields
+                ))
+
+            logger.info("------------volumes:")
+            logger.info(log_listing(
+                'Original', self.original_docker_volumes, *volume_fields
+                ))
+            logger.info(log_listing(
+                'Current', self.get_docker_volume_list(), *volume_fields
+                ))
+            logger.info(log_listing(
+                'New', new_volumes, *volume_fields
+                ))
+
+            # These should have been launched with the --rm flag, so they
+            # should be removed once stopped.
+            for container in new_containers:
+                logger.info("REMOVING %s", container['id'])
+                pexpect.run('docker stop {}'.format(container['id']))
+
+            for image in new_images:
+                logger.info("REMOVING %s", image['id'])
+                pexpect.run('docker rmi {}'.format(image['id']))
+
+            for volume in new_volumes:
+                logger.info("REMOVING %s", volume['name'])
+                pexpect.run('docker volume rm {}'.format(volume['name']))
+
+            self.assertItemsEqual(
+                [x['id'] for x in self.original_docker_containers],
+                [x['id'] for x in self.get_docker_container_list()]
+                )
+
+            self.assertItemsEqual(
+                [x['id'] for x in self.original_docker_images],
+                [x['id'] for x in self.get_docker_image_list()]
+                )
+
+            self.assertItemsEqual(
+                [x['name'] for x in self.original_docker_volumes],
+                [x['name'] for x in self.get_docker_volume_list()]
+                )
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def require_filenames_in_directory(self, patterns=None, directory='.'):
+        '''Check that filenames are found in the indicated directory.
+
+        Each pattern in the list of patterns must match exactly one
+        file in the indicated directory.
+
+        '''
+
+        failure_string_template = (
+            'Unexpected or missing filename match result in {}'
+            ' for pattern r\'{}\':\n{}\n'
+            'Directory contents:\n{}'
+            )
+
+        if patterns:
+            self.assertTrue(os.path.exists(directory))
+            all_filenames = os.listdir(directory)
+            for pattern in patterns:
+                matching_files = [
+                    x for x in all_filenames
+                    if re.match(pattern, x)
+                    ]
+                self.assertTrue(
+                    len(matching_files) == 1,
+                    failure_string_template.format(
+                        directory,
+                        pattern,
+                        matching_files,
+                        os.listdir(directory)
+                        )
+                    )
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    @staticmethod
+    def get_docker_image_list(*expected_images):
+        '''Get the output from "docker image ls" for specified image names.'''
+
+        image_listing_pattern = (
+            r'(?P<name>[^\s]+)\s+'
+            r'(?P<tag>[^\s]+)\s+'
+            r'(?P<id>[0-9a-f]+)\s+'
+            r'(?P<created>.+ago)\s+'
+            r'(?P<size>[^\s]+)'
+            r'\s*$'
+            )
+        image_listing_re = re.compile(image_listing_pattern)
+
+        docker_images_response = pexpect.run('docker image ls')
+
+        image_list = []
+        expected_image_nametag_pairs = [
+            (x.split(':') + ['latest'])[0:2] for x in expected_images
+            ] if expected_images else None
+
+        for line in docker_images_response.split('\n'):
+            match = image_listing_re.match(line)
+            if (
+                    match and (
+                        not expected_images or [
+                            match.groupdict()['name'], match.groupdict()['tag']
+                            ] in expected_image_nametag_pairs
+                        )
+                    ):
+                image_list.append(match.groupdict())
+
+        return image_list
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    @staticmethod
+    def get_docker_container_list(*expected_containers):
+        '''Get the output from "docker ps -a" for specified container names.'''
+
+        container_listing_pattern = (
+            r'(?P<id>[0-9a-f]+)\s+'
+            r'(?P<image>[^\s]+)\s+'
+            r'(?P<command>"[^"]+")\s+'
+            r'(?P<created>.+ago)\s+'
+            r'(?P<status>(Created|Exited.*ago|Up \d+ \S+))\s+'
+            r'(?P<ports>[^\s]+)?\s+'
+            r'(?P<name>[a-z]+_[a-z]+)'
+            # r'\s*$'
+            )
+        container_listing_re = re.compile(container_listing_pattern)
+
+        docker_containers_response = pexpect.run('docker ps -a')
+
+        container_list = []
+        # expected_container_nametag_pairs = [
+        #     (x.split(':') + ['latest'])[0:2] for x in expected_containers
+        #     ] if expected_containers else []
+
+        for line in docker_containers_response.split('\n'):
+            match = container_listing_re.match(line)
+            if match:
+                container_list.append(match.groupdict())
+
+        return container_list
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    @staticmethod
+    def get_docker_volume_list(*expected_volumes):
+        '''Get the output from "docker volume ls" for specified volumes.'''
+
+        volume_listing_pattern = (
+            r'(?P<driver>\S+)\s+'
+            r'(?P<name>\S+)'
+            # r'\s*$'
+            )
+        volume_listing_re = re.compile(volume_listing_pattern)
+
+        docker_volumes_response = pexpect.run('docker volume ls')
+
+        volume_list = []
+
+        for line in docker_volumes_response.split('\n'):
+            match = volume_listing_re.match(line)
+            if match:
+                volume_list.append(match.groupdict())
+
+        return volume_list
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def get_container_details(self, image):
+        '''Run a docker container shell and retrieve several details.'''
+
+        # (detail name, command, result filter) for extracting details
+        # from container command lines.
+        shell_commands = (
+            ('pwd', 'pwd', None),
+            ('phantomjs_path', 'which phantomjs', None),
+            ('phantomjs_perms', 'ls -l $(which phantomjs)', lambda x: x[1:10]),
+            ('config_file', 'ls {}'.format(CONTAINER_CONFIG_PATH), None),
+            ('config_contents', 'cat {}'.format(CONTAINER_CONFIG_PATH), None),
+            )
+
+        command = "docker run --rm -it {} bash".format(image)
+        logger.info('IMAGE: %s', image)
+        logger.info('CONTAINER LAUNCH COMMAND: %s', command)
+        spawn = pexpect.spawn(command)
+
+        container_details = {}
+
+        for field, shell_command, response_filter in shell_commands:
+            container_details[field] = interact(
+                spawn, shell_command, response_filter
+                )
+
+        # Exit the container.
+        spawn.sendcontrol('d')
+
+        # "Expand" the config records if we found a config file.
+        if container_details['config_file'] == CONTAINER_CONFIG_PATH:
+            try:
+                exec(container_details['config_contents'], container_details)
+            except SyntaxError:
+                pass
+            # The '__builtins__' are noise:
+            if '__builtins__' in container_details:
+                del container_details['__builtins__']
+
+        return container_details
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def check_container_details(self, image, expected_details=None):
+        '''Validate docker container details.'''
+
+        # A helper method to retrieve container details of interest,
+        # necessary for configuration items that aren't simple config
+        # file values; e.g. "SWAG_BUCKET".
+        # As written, this won't allow tests to catch *missing*
+        # entries if the *expected* value is None.
+        def get_detail_value(data, detail):
+            '''A helper method to retrieve container details of interest.'''
+
+            def default_get_detail_value_method(data):
+                '''Define a default method for get_detail_value.'''
+                return data.get(detail)
+
+            method = {
+                'SWAG_BUCKET': lambda data: (
+                    data.get('SWAG_OPTS') or {}
+                    ).get('swag.bucket_name')
+                }.get(detail)
+
+            if method is None:
+                method = default_get_detail_value_method
+
+            return method(data)
+
+        image_name, image_tag = image.split(':')
+
+        expected_details = expected_details or {}
+        assert '_common' in expected_details
+
+        expected_container_details = dict(expected_details['_common'])
+        if image_name in expected_details:
+            expected_container_details.update(expected_details[image_name])
+
+        container_details = self.get_container_details(image)
+
+        clean_comparison = {
+            'missing': {},
+            'incorrect': {}
+            }
+        comparison = {
+            'missing': {},
+            'incorrect': {}
+            }
+
+        for k, v in expected_container_details.iteritems():
+
+            logger.info(' -- checking configuration item %s...', k)
+            logger.info('    expected: %s', v)
+
+            actual = get_detail_value(container_details, k)
+
+            # if k not in container_details:
+            # TODO: Note that this fails if we're *expecting* None.
+            if actual is None:
+                comparison['missing'][k] = v
+                logger.info('    actual: -')
+
+            elif actual != v:
+                comparison['incorrect'][k] = {
+                    'expected': v,
+                    'actual': actual
+                    }
+                logger.info(comparison['incorrect'][k])
+
+            else:
+                logger.info('    actual:   %s', actual)
+
+        logger.info("comparing %s", image)
+        logger.info(comparison)
+        logger.info('')
+        self.assertEqual(comparison, clean_comparison)
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def case_worker(
+            self,
+            target,
+            images_tag=None,
+            expected_artifacts=None,
+            expected_docker_images=None,
+            expected_details=None,
+            expect_phantom=True,
+            expect_aardvark=True,
+            add_env=None
+            ):
+        '''Carry out common test steps.
+        '''
+
+        logger.info(
+            ' -' * 24 + '\n working case: %s\n' + ' -' * 24,
+            target
+            )
+
+        # Unless we finish without a failure Exception, tell tearDown
+        # not to clean up artifacts. We reset this below.
+        self.delete_artifacts = False
+
+        # A unique string to add to certain test case artifact names
+        # to avoid clobbering/colliding.
+        images_tag = images_tag or self.testcase_tag
+        logger.info('Test case images tag is %s', images_tag)
+
+        expected_artifacts = expected_artifacts or []
+        expected_docker_images = expected_docker_images or []
+        tagged_expected_docker_images = [
+            x + ':{}'.format(images_tag)
+            for x in expected_docker_images
+            ]
+
+        # expected_details is a two level dict so a straightforward
+        # dict update isn't possible.
+        expected_details = expected_details or {}
+        expected_details['_common'] = expected_details.get('_common') or {}
+        expected_details['_common']['config_file'] = CONTAINER_CONFIG_PATH
+        expected_details['_common']['phantomjs_perms'] = (
+            CONTAINER_PHANTOMJS_PERMS
+            )
+
+        # Environment variables to add to the pexpect interaction with
+        # containers.
+        add_env = dict(add_env or {}, AARDVARK_IMAGES_TAG=images_tag)
+
+        # Fetch the default environment settings so we can update
+        # those with specific case settings.
+        spawn_env = dict(
+            map(
+                lambda x: x.strip().split('='),
+                pexpect.run('env').strip().split("\n"))
+            )
+
+        command = 'make {}'.format(target)
+        logger.info('COMMAND: %s', command)
+
+        # TODO: A sort of halfhearted attempt at adjusting for network
+        # conditions. Need some kind of not-too-slow way to check for
+        # network speed, say a sample download or something.
+        (result, exitstatus) = pexpect.run(
+            command,
+            timeout=(
+                PEXPECT_TIMEOUTS.get(target) or PEXPECT_TIMEOUTS['default'] *
+                NETWORK_SPEED_FACTOR
+                ),
+            withexitstatus=True,
+            env=dict(spawn_env, **add_env)
+            )
+
+        self.assertEqual(
+            exitstatus, 0,
+            'command "{}" exited with exit status {}'.format(
+                command, exitstatus
+                )
+            )
+
+        # Sanity check - we didn't delete the Makefile or any of the
+        # Dockerfiles.
+        self.assertEqual(
+            [x for x in self.initial_contents if x not in os.listdir('.')],
+            []
+            )
+
+        if expected_docker_images:
+            self.assertItemsEqual(
+                [
+                    [x['name'], x['tag']]
+                    for x in self.get_docker_image_list(
+                        *tagged_expected_docker_images
+                        )
+                    ],
+                [x.split(':') for x in tagged_expected_docker_images]
+                )
+
+        for image in tagged_expected_docker_images:
+            self.check_container_details(image, expected_details)
+
+        if expect_phantom:
+            self.require_filenames_in_directory(
+                [
+                    r'phantomjs$',
+                    r'phantomjs-.*-linux-x86_64$',
+                    r'phantomjs-.*-linux-x86_64.tar.bz2$',
+                    r'phantomjs-.*-linux-x86_64.tar.bz2.shasum$'
+                    ]
+                )
+
+        if expect_aardvark:
+            self.require_filenames_in_directory([r'aardvark$'])
+
+        if expected_artifacts:
+            self.require_filenames_in_directory(
+                expected_artifacts,
+                directory=ARTIFACT_DIRECTORY
+                )
+
+        # We made it through, tell tearDown we can clean up artifacts.
+        self.delete_artifacts = True
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class TestDockerContainerConstruction(TestDockerBase):
+    '''Test cases for docker container construction.'''
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def test_make_phantomjs(self):
+        '''Test "make phantomjs".'''
+
+        self.case_worker(
+            target='phantomjs',
+            expect_aardvark=False,
+            expect_phantom=True,
+            )
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def test_make_aardvark(self):
+        '''Test "make phantomjs".'''
+
+        self.case_worker(
+            target='aardvark',
+            expect_aardvark=True,
+            expect_phantom=False,
+            )
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def test_make_aardvark_base(self):
+        '''Test "make aardvark-base".'''
+
+        self.case_worker(
+            target='aardvark-base',
+            expected_docker_images=[
+                'aardvark-base'
+                ],
+            expected_details={
+                '_common': {
+                    'pwd': '/etc/aardvark',
+                    'NUM_THREADS': 5,
+                    'PHANTOMJS': EXPECTED_PHANTOMJS_PATH,
+                    'ROLENAME': 'Aardvark',
+                    'SQLALCHEMY_DATABASE_URI': EXPECTED_SQLITE_DB_URI,
+                    'SQLALCHEMY_TRACK_MODIFICATIONS': EXPECTED_SQL_TRACK_MODS,
+                    }
+                },
+            expected_artifacts=[
+                'aardvark-base-docker-build'
+                ],
+            )
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def test_make_aardvark_base_set_env_variables(self):
+        '''Test "make aardvark-base" with build time environment variables.'''
+
+        aardvark_db_uri = 'blort://blah.bleh.bloo/bing/bang/bong'
+        aardvark_role = 'llama'
+        swag_bucket = 'ponponpon'
+
+        self.case_worker(
+            target='aardvark-base',
+            expected_docker_images=[
+                'aardvark-base'
+                ],
+            expected_details={
+                '_common': {
+                    'pwd': '/etc/aardvark',
+                    'NUM_THREADS': 5,
+                    'PHANTOMJS': EXPECTED_PHANTOMJS_PATH,
+                    'ROLENAME': aardvark_role,
+                    'SQLALCHEMY_DATABASE_URI': aardvark_db_uri,
+                    'SQLALCHEMY_TRACK_MODIFICATIONS': EXPECTED_SQL_TRACK_MODS,
+                    'SWAG_BUCKET': swag_bucket,
+                    }
+                },
+            expected_artifacts=[
+                'aardvark-base-docker-build'
+                ],
+            add_env={
+                'AARDVARK_DB_URI': aardvark_db_uri,
+                'AARDVARK_ROLE': aardvark_role,
+                'SWAG_BUCKET': swag_bucket,
+                }
+            )
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def test_make_aardvark_all(self):
+        '''Test "make aardvark-all".'''
+
+        self.case_worker(
+            target='aardvark-all',
+            expected_docker_images=[
+                'aardvark-base',
+                'aardvark-collector',
+                'aardvark-apiserver',
+                ],
+            expected_details={
+                '_common': {
+                    'pwd': '/usr/share/aardvark-data',
+                    'NUM_THREADS': 5,
+                    'PHANTOMJS': EXPECTED_PHANTOMJS_PATH,
+                    'ROLENAME': 'Aardvark',
+                    'SQLALCHEMY_DATABASE_URI': EXPECTED_SQLITE_DB_URI,
+                    'SQLALCHEMY_TRACK_MODIFICATIONS': EXPECTED_SQL_TRACK_MODS,
+                    },
+                'aardvark-base': {
+                    'pwd': '/etc/aardvark',
+                    },
+                },
+            expected_artifacts=[
+                'aardvark-base-docker-build',
+                'aardvark-apiserver-docker-build',
+                'aardvark-collector-docker-build',
+                ],
+            )
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    def test_make_aardvark_sqlite(self):
+        '''Test "make aardvark-sqlite".'''
+
+        self.case_worker(
+            target='aardvark-sqlite',
+            expected_docker_images=[
+                'aardvark-base',
+                'aardvark-data-init',
+                'aardvark-collector',
+                'aardvark-apiserver',
+                ],
+            expected_details={
+                '_common': {
+                    'pwd': '/usr/share/aardvark-data',
+                    'NUM_THREADS': 5,
+                    'PHANTOMJS': EXPECTED_PHANTOMJS_PATH,
+                    'ROLENAME': 'Aardvark',
+                    'SQLALCHEMY_DATABASE_URI': EXPECTED_SQLITE_DB_URI,
+                    'SQLALCHEMY_TRACK_MODIFICATIONS': EXPECTED_SQL_TRACK_MODS,
+                    },
+                'aardvark-base': {
+                    'pwd': '/etc/aardvark',
+                    },
+                },
+            expected_artifacts=[
+                'aardvark-base-docker-build',
+                'aardvark-data-docker-build',
+                'aardvark-data-docker-run',
+                'aardvark-apiserver-docker-build',
+                'aardvark-collector-docker-build',
+                ],
+            )
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Define test suites.
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+load_case = unittest.TestLoader().loadTestsFromTestCase
+all_suites = {
+    'testdockercontainerconstruction': load_case(
+        TestDockerContainerConstruction
+        ),
+    }
+
+master_suite = unittest.TestSuite(all_suites.values())
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Run "make help" for documentation.

This adds Dockerfiles to create a base image from which docker images for the api server and data collector are built. It will also build and initialize a shared sqlite data volume if specified.

It would be good to try this out in more environments; I've tested it with the test file and manually and it looks good, but I didn't test it with swag or with a non-sqlite data URI.

I also need an example of a non-sqlite database URI for the documentation.