### PR TITLE
Running the phaton.js with interactice mode turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ python setup.py develop
  - libpq-dev
 
 **Note**: Aardvark requires at least phantomjs 2.1.1.  We've seen odd behavior running with older versions. In order to use phanton_js you will need to set the env variable as described below, otherwise it will try to open in interactive mode and probably it will not properly work:
- ```export QT_QPA_PLATFORM=offscreen
+ ```bash
+ export QT_QPA_PLATFORM=offscreen
  ```
 
 ## Configure Aardvark

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ python setup.py develop
 ### Known Dependencies
  - [PhantomJS*](http://phantomjs.org/download.html)
  - libpq-dev
- 
-**Note**: Aardvark requires at least phantomjs 2.1.1.  We've seen odd behavior running with older versions.
+
+**Note**: Aardvark requires at least phantomjs 2.1.1.  We've seen odd behavior running with older versions. In order to use phanton_js you will need to set the env variable as described below, otherwise it will try to open in interactive mode and probably it will not properly work:
+ ```export QT_QPA_PLATFORM=offscreen
+ ```
 
 ## Configure Aardvark
 
@@ -34,8 +36,8 @@ Aardvark can use SWAG to look up accounts. https://github.com/Netflix-Skunkworks
 Do you use SWAG to track accounts? [yN]: no
 ROLENAME: Aardvark
 DATABASE [sqlite:////home/github/aardvark/aardvark.db]:
-# Threads [5]: 
-Path to phantomjs: 
+# Threads [5]:
+Path to phantomjs:
 
 >> Writing to config.py
 ```


### PR DESCRIPTION
In order to better run the Aardvark, I would recommend setting the local env to turn off the interactive mode of the phanton.sj.
This modification will make it easier the setup of this tool.