### PR TITLE
Truncate serviceName and serviceNamespace

### DIFF
--- a/aardvark/model.py
+++ b/aardvark/model.py
@@ -69,6 +69,9 @@ class AdvisorData(db.Model):
     @staticmethod
     def create_or_update(item_id, lastAuthenticated, serviceName, serviceNamespace, lastAuthenticatedEntity,
                          totalAuthenticatedEntities):
+        serviceName = serviceName[:128]
+        serviceNamespace = serviceNamespace[:64]
+        item = None
         try:
             item = AdvisorData.query.filter(AdvisorData.item_id == item_id).filter(AdvisorData.serviceNamespace ==
                                                                                    serviceNamespace).scalar()


### PR DESCRIPTION
After latest AWS re:Invent, Amazon introduced a bunch of new services that are currently being rolled out across accounts.

One of these, AWS Server Migration Service, reports a `serviceName` entry like `AWS Server Migration Service automates the migration of your on-premises VMware vSphere or Microsoft Hyper-V/SCVMM virtual machines to the AWS Cloud.` which is longer than 128 characters and doesn't fit into the `serviceName`  column.

Relevant excerpt from logs:
```
InvalidRequestError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely) (psycopg2.DataError) value too long for type character varying(128)
 [SQL: 'INSERT INTO advisor_data (item_id, "lastAuthenticated", "serviceName", "serviceNamespace", "lastAuthenticatedEntity", "totalAuthenticatedEntities") VALUES (%(item_id)s, %(lastAuthenticated)s, %(serviceName)s, %(serviceNamespace)s, %(lastAuthenticatedEntity)s, %(totalAuthenticatedEntities)s) RETURNING advisor_data.id'] [parameters: {'item_id': 674, 'totalAuthenticatedEntities': 0, 'serviceName': u'AWS Server Migration Service automates the migration of your on-premises VMware vSphere or Microsoft Hyper-V/SCVMM virtual machines to the AWS Cloud.', 'lastAuthenticated': 0, 'serviceNamespace': u'sms', 'lastAuthenticatedEntity': u''}] (Background on this error at: http://sqlalche.me/e/9h9h)
```

This PR (badly) attempts to hotfix this issue by truncating both `serviceName` and `serviceNamespace` to their declared column limits. I'm not entirely aware of the ramifications of truncating such inputs for Aardvark so guidance is highly appreciated 😅 