### PR TITLE
Fix Aardvark Update

### DIFF
--- a/aardvark/__about__.py
+++ b/aardvark/__about__.py
@@ -7,7 +7,7 @@ __title__ = "aardvark"
 __summary__ = ("Multi-Account AWS IAM Access Advisor API")
 __uri__ = "https://github.com/Netflix-Skunkworks/aardvark"
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __author__ = "Patrick Kelley, Travis McPeak"
 __email__ = "pkelley@netflix.com, tmcpeak@netflix.com"


### PR DESCRIPTION
This commit fixes a bug introduced by the previous change to
move to the Access Advisor API. Specifically we needed to convert
the new AWS API datetime to epoch, but the object was never added.

This caused updates to not happen.