### PR TITLE
Adding error handling for transient roles.

### DIFF
--- a/aardvark/updater/__init__.py
+++ b/aardvark/updater/__init__.py
@@ -113,8 +113,11 @@ class AccountToUpdate(object):
     def _generate_job_ids(self, iam, arns):
         jobs = {}
         for role_arn in arns:
-            job_id = self._generate_service_last_accessed_details(iam, role_arn)
-            jobs[job_id] = role_arn
+            try:
+                job_id = self._generate_service_last_accessed_details(iam, role_arn)
+                jobs[job_id] = role_arn
+            except Exception as e:
+                self.current_app.logger.error('Could not gather data from {0}.'.format(role_arn))
         return jobs
 
     def _get_job_results(self, iam, jobs):
@@ -134,7 +137,11 @@ class AccountToUpdate(object):
             # Pull next job ID
             job_id = job_queue.pop()
             role_arn = jobs[job_id]
-            details = self._get_service_last_accessed_details(iam, job_id)
+            try:
+                details = self._get_service_last_accessed_details(iam, job_id)
+            except Exception as e:
+                self.current_app.logger.error('Could not gather data from {0}.'.format(role_arn))
+                continue
 
             # Check job status
             if details['JobStatus'] == 'IN_PROGRESS':


### PR DESCRIPTION
In very dynamic environments with roles constantly coming up and down, aardvark threads will often fail. Adding simple try/except blocks to allow them to work.

```
NoSuchEntityException: An error occurred (NoSuchEntity) when calling the GenerateServiceLastAccessedDetails operation: ARN arn:aws:iam::XXXXXX:policy/YYYYY does not exist.
2019-06-20 22:10:27,950 INFO: Thread #4 persisting data for account XXXXXX [in aardvark/aardvark/manage.py:76]
2019-06-20 22:10:27,951 WARNING: Cannot persist Access Advisor Data as no data was collected. [in aardvark/aardvark/manage.py:94]
```