### PR TITLE
Handle missing/empty LastAuthenticated; handle NoSuchEntityException in updater

### DIFF
--- a/aardvark/manage.py
+++ b/aardvark/manage.py
@@ -79,6 +79,7 @@ class UpdateAccountThread(threading.Thread):
                 persist_aa_data(self.app, aa_data)
                 DB_LOCK.release()
 
+                self.app.logger.info("Thread #{} FINISHED persisting data for account {}".format(self.thread_ID, account_num))
             else:
                 QUEUE_LOCK.release()
 

--- a/aardvark/updater/__init__.py
+++ b/aardvark/updater/__init__.py
@@ -116,7 +116,10 @@ class AccountToUpdate(object):
             try:
                 job_id = self._generate_service_last_accessed_details(iam, role_arn)
                 jobs[job_id] = role_arn
-            except Exception as e:
+            except iam.exceptions.NoSuchEntityException:
+                """ We're here because this ARN disappeared since the call to self._get_arns(). Log the missing ARN and move along.  """
+                self.current_app.logger.info('ARN {arn} found gone when fetching details'.format(arn=role_arn))
+            except Exception:
                 self.current_app.logger.error('Could not gather data from {0}.'.format(role_arn))
         return jobs
 
@@ -139,7 +142,7 @@ class AccountToUpdate(object):
             role_arn = jobs[job_id]
             try:
                 details = self._get_service_last_accessed_details(iam, job_id)
-            except Exception as e:
+            except Exception:
                 self.current_app.logger.error('Could not gather data from {0}.'.format(role_arn))
                 continue
 
@@ -194,4 +197,3 @@ class AccountToUpdate(object):
                 job_id=job_id,
                 arn=role_arn,
             ))
-


### PR DESCRIPTION
LastAuthenticated:
- when LastAuthenticated is missing/empty in the AA response but the service has a previous, non-zero LastAuthenticated timestamp, consider the service as not being accessed in the past year
- if LastAuthenticated is present, non-zero and less than the previous LastAuthenticated, keep the current behavior (log the error, don't persist data for the current item)

NoSuchEntityException:
- it's possible that (in dynamic environments especially) that a role was deleted after it was picked up by the _get_arns() method. When trying to fetch last access details for it, later, a NoSuchEntityException will be raised. Handle this case gracefully, i.e. log the event and continue with the next role instead of bailing out.