### PR TITLE
AWS GovCloud Support

### DIFF
--- a/aardvark/manage.py
+++ b/aardvark/manage.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import json
 import os
 try:
-    import queue as Queue # Queue renamed to queue in py3 
+    import queue as Queue # Queue renamed to queue in py3
 except ModuleNotFoundError:
     import Queue
 import re
@@ -247,6 +247,7 @@ def config(aardvark_role_param, bucket_param, db_uri_param, num_threads_param, n
             filedata.write("SWAG_SERVICE_ENABLED_REQUIREMENT = None\n")
         filedata.write('ROLENAME = "{role}"\n'.format(role=aardvark_role))
         filedata.write('REGION = "us-east-1"\n')
+        filedata.write('ARN_PARTITION = "aws"\n')
         filedata.write('SQLALCHEMY_DATABASE_URI = "{uri}"\n'.format(uri=db_uri))
         filedata.write('SQLALCHEMY_TRACK_MODIFICATIONS = False\n')
         filedata.write('NUM_THREADS = {num_threads}\n'.format(num_threads=num_threads))

--- a/aardvark/updater/__init__.py
+++ b/aardvark/updater/__init__.py
@@ -19,7 +19,8 @@ class AccountToUpdate(object):
             'account_number': account_number,
             'assume_role': role_name,
             'session_name': 'aardvark',
-            'region': self.current_app.config.get('REGION') or 'us-east-1'
+            'region': self.current_app.config.get('REGION') or 'us-east-1',
+            'arn_partition': self.current_app.config.get('ARN_PARTITION') or 'aws'
         }
         self.max_access_advisor_job_wait = 5 * 60  # Wait 5 minutes before giving up on jobs
 

--- a/aardvark/updater/__init__.py
+++ b/aardvark/updater/__init__.py
@@ -94,7 +94,7 @@ class AccountToUpdate(object):
         :return: boto3 IAM client in target account & role
         """
         client = boto3_cached_conn(
-            'iam', account_number=self.account_number, assume_role=self.role_name)
+            'iam', **self.conn_details)
         return client
 
     def _call_access_advisor(self, iam, arns):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
 click-log==0.3.2
-cloudaux==1.7.0
+cloudaux==1.8.0
 decorator==4.4.0
 deepdiff==3.3.0
 defusedxml==0.6.0


### PR DESCRIPTION
Issue: When using GovCloud or other AWS partitions the role generated via the role name has an invalid ARN. For example, when using `us-gov-east-1` it generates the following:

`arn:aws:iam::<account id>:role/Aardvark`

which should be:

`arn:aws-us-gov:iam::<account id>:role/Aardvark`

This pull request adds a new configuration item to the `config.py` called `ARN_PARTITION`. By default `ARN_PARTITION` is set to `aws` to maintain backwards compatibility. This can be overridden with `aws-us-gov` to generate proper ARNs in those regions.