### PR TITLE
Add Blinker signals to updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea/
+
 # mypy stuff
 .mypy_cache/
 

--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ INFO: Thread #1 FINISHED persisting data for account 123456789012
 ### Available signals
 
 | Class | Signals |
-|-------|-------------|
+|-------|---------|
 | `manage.UpdateAccountThread` | `on_ready`, `on_complete`, `on_failure` |
-| `updater.AccountToUpdate` | `on_ready`, `on_complete`, `on_failure` |
+| `updater.AccountToUpdate` | `on_ready`, `on_complete`, `on_error`, `on_failure` |
 
 ## TODO:
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,62 @@ The `regex` query is only supported in Postgres (natively) and SQLite (via some 
 ### TLS
 We recommend enabling TLS for any service. Instructions for setting up TLS are out of scope for this document.
 
+## Signals
+
+> New in v0.4.0
+
+Aardvark uses [Blinker](https://pythonhosted.org/blinker/) for signals in its update process. These signals can be used
+for things like emitting metrics, additional logging, or taking more actions on accounts. You can use them by writing a
+script that defines your handlers and calls `aardvark.manage.main()`. For example, create a file called
+`signals_example.py` with the following contents:
+
+```python
+import logging
+
+from aardvark.manage import main
+from aardvark.updater import AccountToUpdate
+
+logger = logging.getLogger('aardvark_signals')
+
+
+@AccountToUpdate.on_ready.connect
+def handle_on_ready(sender):
+    logger.info(f"got on_ready from {sender}")
+
+
+@AccountToUpdate.on_complete.connect
+def handle_on_complete(sender):
+    logger.info(f"got on_complete from {sender}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+This file can now be invoked in the same way as `manage.py`:
+
+```bash
+python signals_example.py update -a cool_account
+```
+
+The log output will be similar to the following:
+
+```
+INFO: getting bucket swag-bucket
+INFO: Thread #1 updating account 123456789012 with all arns
+INFO: got on_ready from <aardvark.updater.AccountToUpdate object at 0x10c379b50>
+INFO: got on_complete from <aardvark.updater.AccountToUpdate object at 0x10c379b50>
+INFO: Thread #1 persisting data for account 123456789012
+INFO: Thread #1 FINISHED persisting data for account 123456789012
+```
+
+### Available signals
+
+| Class | Signals |
+|-------|-------------|
+| `manage.UpdateAccountThread` | `on_ready`, `on_complete`, `on_failure` |
+| `updater.AccountToUpdate` | `on_ready`, `on_complete`, `on_failure` |
+
 ## TODO:
 
 See [TODO](TODO.md)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ We recommend enabling TLS for any service. Instructions for setting up TLS are o
 
 ## Signals
 
-> New in v0.4.0
+> New in v0.3.1
 
 Aardvark uses [Blinker](https://pythonhosted.org/blinker/) for signals in its update process. These signals can be used
 for things like emitting metrics, additional logging, or taking more actions on accounts. You can use them by writing a

--- a/aardvark/__about__.py
+++ b/aardvark/__about__.py
@@ -7,7 +7,7 @@ __title__ = "aardvark"
 __summary__ = ("Multi-Account AWS IAM Access Advisor API")
 __uri__ = "https://github.com/Netflix-Skunkworks/aardvark"
 
-__version__ = "0.4.0"
+__version__ = "0.3.1"
 
 __author__ = "Patrick Kelley, Travis McPeak, Patrick Sanders"
 __email__ = "aardvark-maintainers@netflix.com"

--- a/aardvark/__about__.py
+++ b/aardvark/__about__.py
@@ -10,7 +10,7 @@ __uri__ = "https://github.com/Netflix-Skunkworks/aardvark"
 __version__ = "0.4.0"
 
 __author__ = "Patrick Kelley, Travis McPeak, Patrick Sanders"
-__email__ = "psanders@netflix.com"
+__email__ = "aardvark-maintainers@netflix.com"
 
 __license__ = "Apache License, Version 2.0"
 __copyright__ = "Copyright 2020 {0}".format(__author__)

--- a/aardvark/__about__.py
+++ b/aardvark/__about__.py
@@ -7,10 +7,10 @@ __title__ = "aardvark"
 __summary__ = ("Multi-Account AWS IAM Access Advisor API")
 __uri__ = "https://github.com/Netflix-Skunkworks/aardvark"
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
-__author__ = "Patrick Kelley, Travis McPeak"
-__email__ = "pkelley@netflix.com, tmcpeak@netflix.com"
+__author__ = "Patrick Kelley, Travis McPeak, Patrick Sanders"
+__email__ = "psanders@netflix.com"
 
 __license__ = "Apache License, Version 2.0"
-__copyright__ = "Copyright 2017 {0}".format(__author__)
+__copyright__ = "Copyright 2020 {0}".format(__author__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aniso8601==8.0.0
 astroid==2.3.1
 attrs==19.3.0
 better-exceptions==0.1.7
+blinker==1.4
 boto==2.49.0
 boto3==1.9.252
 botocore==1.12.252

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ with open(os.path.join(ROOT, "aardvark", "__about__.py")) as f:
 install_requires = [
     'requests>=2.9.1',
     'better_exceptions==0.1.7',
+    'blinker>=1.4',
     'Bunch==1.0.1',
     'Flask-SQLAlchemy==2.2',
     'cloudaux>=1.2.0',


### PR DESCRIPTION
Use [Blinker](https://pythonhosted.org/blinker/) to add signals for extensibility of functionality in the `update` flow. See `README.md` updates for more information about these changes.

The intent of this addition is to give users the ability to extend Aardvark and add integrations without having to modify Aardvark itself. Some of the possible uses could be patterns along the lines of "upload account data to S3 after gathering updates" or "emit a metric when a task fails".

From the Blinker documentation:

Blinker provides fast & simple object-to-object and broadcast signaling for Python objects.

The core of Blinker is quite small but provides powerful features:
- a global registry of named signals
- anonymous signals
- custom name registries
- permanently or temporarily connected receivers
- automatically disconnected receivers via weak referencing
- sending arbitrary data payloads
- collecting return values from signal receivers
- thread safety