### PR TITLE
Bump flask from 1.0.2 to 2.3.2 , Bump Flask-SQLAlchemy to 3.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,10 @@ docutils==0.15.2
 dogpile.cache==0.8.0
 flagpole==1.1.1
 flasgger==0.6.3
-Flask==1.0.2
+Flask==2.3.2
 Flask-RESTful==0.3.5
 Flask-Script==2.0.5
-Flask-SQLAlchemy>=2.5
+Flask-SQLAlchemy==3.0.5
 gunicorn==19.7.1
 idna==2.8
 importlib-metadata


### PR DESCRIPTION
updated the versions of required dependencies