### PR TITLE
Update __init__.py

### DIFF
--- a/aardvark/updater/__init__.py
+++ b/aardvark/updater/__init__.py
@@ -216,7 +216,7 @@ class AccountToUpdate(object):
 
                     updated_item['LastAuthenticated'] = last_auth
                     updated_list.append(updated_item)
-                if details.get('Truncated', False):
+                if details.get('IsTruncated', True):
                     try:
                         details = self._get_service_last_accessed_details(iam, job_id, marker=details.get('Marker'))
                     except Exception as e:


### PR DESCRIPTION
Fixing parameter from Get Access Detaill.

The correct parameter when a role has more than 200 service is "IsTruncate"  and needs to be true as says this documentation:

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam/client/get_service_last_accessed_details.html

If the current configuration has a role that has more than 200 services, Repokid will think that this role is not using some services that doesn`t have in the database aardvark as aardvark is not able to collect all services from the role due this limitation of the parameter.